### PR TITLE
fix: remove null optional elements before jsonencode is called

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -5,6 +5,7 @@ An end-to-end example that uses the IBM Cloud Terraform provider to create the f
 - A resource group, if one is not passed in.
 - A Key Protect instance with a root key.
 - An instance of Databases for MongoDB with BYOK encryption.
+- Set 250 max connection for Databases for MongoDB instance.
 - Service credentials for the database instance.
 - A sample virtual private cloud (VPC).
 - A context-based restriction (CBR) rule to only allow MongoDB to be accessible from within the VPC.

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -83,6 +83,9 @@ module "mongodb" {
   access_tags                = var.access_tags
   tags                       = var.resource_tags
   service_credential_names   = var.service_credential_names
+  configuration = {
+    max_connections = 250
+  }
   cbr_rules = [
     {
       description      = "${var.prefix}-mongodb access only from vpc"

--- a/main.tf
+++ b/main.tf
@@ -45,17 +45,17 @@ resource "time_sleep" "wait_for_authorization_policy" {
 }
 
 resource "ibm_database" "mongodb" {
-  depends_on                = [ibm_iam_authorization_policy.kms_policy]
-  name                      = var.instance_name
-  location                  = var.region
-  plan                      = var.plan
-  service                   = "databases-for-mongodb"
-  version                   = var.mongodb_version
-  resource_group_id         = var.resource_group_id
-  adminpassword             = var.admin_pass
-  tags                      = var.tags
-  service_endpoints         = var.endpoints
-  plan_validation           = var.plan_validation
+  depends_on        = [ibm_iam_authorization_policy.kms_policy]
+  name              = var.instance_name
+  location          = var.region
+  plan              = var.plan
+  service           = "databases-for-mongodb"
+  version           = var.mongodb_version
+  resource_group_id = var.resource_group_id
+  adminpassword     = var.admin_pass
+  tags              = var.tags
+  service_endpoints = var.endpoints
+  plan_validation   = var.plan_validation
   # remove elements with null values: see https://github.com/terraform-ibm-modules/terraform-ibm-icd-postgresql/issues/273
   configuration             = var.configuration != null ? jsonencode({ for k, v in var.configuration : k => v if v != null }) : null
   key_protect_key           = var.kms_key_crn

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "ibm_database" "mongodb" {
   tags                      = var.tags
   service_endpoints         = var.endpoints
   plan_validation           = var.plan_validation
-  configuration             = var.configuration != null ? jsonencode(var.configuration) : null
+  configuration             = var.configuration != null ? jsonencode({ for k, v in var.configuration : k => v if v != null }) : null
   key_protect_key           = var.kms_key_crn
   backup_encryption_key_crn = local.backup_encryption_key_crn
 

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,7 @@ resource "ibm_database" "mongodb" {
   tags                      = var.tags
   service_endpoints         = var.endpoints
   plan_validation           = var.plan_validation
+  # remove elements with null values: see https://github.com/terraform-ibm-modules/terraform-ibm-icd-postgresql/issues/273
   configuration             = var.configuration != null ? jsonencode({ for k, v in var.configuration : k => v if v != null }) : null
   key_protect_key           = var.kms_key_crn
   backup_encryption_key_crn = local.backup_encryption_key_crn

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -481,7 +481,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 182
+        "line": 183
       }
     },
     "ibm_resource_tag.mongodb_tag": {
@@ -497,7 +497,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 131
+        "line": 132
       }
     },
     "time_sleep.wait_for_authorization_policy": {
@@ -529,7 +529,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 210
+        "line": 211
       }
     }
   },
@@ -608,7 +608,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 142
+        "line": 143
       }
     }
   }


### PR DESCRIPTION


### Description

jsonencode sets null for any optional value that is not set. postgresql API doesn't like that. We need to remove null versions. 

https://github.com/terraform-ibm-modules/terraform-ibm-icd-postgresql/issues/273

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
