### PR TITLE
fix(deps): service end of life for mongodb 5.0

### DIFF
--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -94,7 +94,7 @@ func TestRunCompleteUpgradeExample(t *testing.T) {
 		BestRegionYAMLPath: regionSelectionPath,
 		ResourceGroup:      resourceGroup,
 		TerraformVars: map[string]interface{}{
-			"mongodb_version": "5.0", // Always lock to the lowest supported MongoDB version
+			"mongodb_version": "6.0", // Always lock to the lowest supported MongoDB version
 			"users": []map[string]interface{}{
 				{
 					"name":     "testuser",

--- a/variables.tf
+++ b/variables.tf
@@ -21,9 +21,8 @@ variable "mongodb_version" {
     condition = anytrue([
       var.mongodb_version == null,
       var.mongodb_version == "6.0",
-      var.mongodb_version == "5.0",
     ])
-    error_message = "Version must be 5.0 or 6.0. If no value is passed, the current preferred version of IBM Cloud Databases is used."
+    error_message = "Version must be 6.0. If no value is passed, the current preferred version of IBM Cloud Databases is used."
   }
 }
 


### PR DESCRIPTION
### Description

MongoDB 5.0 has reached end of life.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Remove support for MongoDB 5.0.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
