### PR TITLE
fix: updated the other_test.go to use TestOptionsDefault function

### DIFF
--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -3,9 +3,11 @@ package test
 
 import (
 	"fmt"
+	"strings"
 
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 )
@@ -13,11 +15,14 @@ import (
 func testPlanICDVersions(t *testing.T, version string) {
 	t.Parallel()
 
-	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
+	prefix := fmt.Sprintf("mongo-%s", strings.ToLower(random.UniqueId()))
+	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
 		Testing:      t,
 		TerraformDir: "examples/basic",
 		TerraformVars: map[string]interface{}{
 			"mongodb_version": version,
+			"prefix":          prefix,
+			"region":          fmt.Sprint(permanentResources["mongodbRegion"]),
 		},
 		CloudInfoService: sharedInfoSvc,
 	})
@@ -38,15 +43,15 @@ func TestPlanICDVersions(t *testing.T) {
 
 func TestRunRestoredDBExample(t *testing.T) {
 	t.Parallel()
-
-	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  "examples/backup-restore",
-		Prefix:        "mongo-restored",
-		Region:        fmt.Sprint(permanentResources["mongodbRegion"]),
-		ResourceGroup: resourceGroup,
+	prefix := fmt.Sprintf("mongodb-res-%s", strings.ToLower(random.UniqueId()))
+	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
+		Testing:      t,
+		TerraformDir: "examples/backup-restore",
 		TerraformVars: map[string]interface{}{
 			"existing_database_crn": permanentResources["mongodbCrn"],
+			"prefix":                prefix,
+			"region":                fmt.Sprint(permanentResources["mongodbRegion"]),
+			"resource_group":        resourceGroup,
 		},
 		CloudInfoService: sharedInfoSvc,
 	})


### PR DESCRIPTION
### Description
updated the other_test.go to use TestOptionsDefault function as TestOptionsDefaultWithVars function have default variable resource_tag which is not in our module ,pipeline was failing due to this.

issue: https://github.ibm.com/GoldenEye/issues/issues/13410

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

This issue update Test functions in other_test.go pipeline

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
