### PR TITLE
fix: update DA inputs

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,8 +3,8 @@
 ##############################################################################
 
 locals {
-  secret_manager_guid   = var.existing_secret_manager_instance_guid == null ? module.secrets_manager[0].secrets_manager_guid : var.existing_secret_manager_instance_guid
-  secret_manager_region = var.existing_secret_manager_instance_region == null ? var.region : var.existing_secret_manager_instance_region
+  secrets_manager_guid   = var.existing_secrets_manager_instance_guid == null ? module.secrets_manager[0].secrets_manager_guid : var.existing_secrets_manager_instance_guid
+  secrets_manager_region = var.existing_secrets_manager_instance_region == null ? var.region : var.existing_secrets_manager_instance_region
   service_credential_names = {
     "es_admin" : "Administrator",
     "es_operator" : "Operator",
@@ -131,7 +131,7 @@ module "icd_mongodb" {
 
 # Create Secrets Manager Instance (if not using existing one)
 module "secrets_manager" {
-  count                = var.existing_secret_manager_instance_guid == null ? 1 : 0
+  count                = var.existing_secrets_manager_instance_guid == null ? 1 : 0
   source               = "terraform-ibm-modules/secrets-manager/ibm"
   version              = "2.2.1"
   resource_group_id    = module.resource_group.resource_group_id
@@ -146,8 +146,8 @@ module "secrets_manager" {
 module "secrets_manager_secrets_group" {
   source               = "terraform-ibm-modules/secrets-manager-secret-group/ibm"
   version              = "1.3.3"
-  region               = local.secret_manager_region
-  secrets_manager_guid = local.secret_manager_guid
+  region               = local.secrets_manager_region
+  secrets_manager_guid = local.secrets_manager_guid
   #tfsec:ignore:general-secrets-no-plaintext-exposure
   secret_group_name        = "${var.prefix}-es-secrets"
   secret_group_description = "service secret-group" #tfsec:ignore:general-secrets-no-plaintext-exposure
@@ -158,8 +158,8 @@ module "secrets_manager_service_credentials_user_pass" {
   source                  = "terraform-ibm-modules/secrets-manager-secret/ibm"
   version                 = "1.7.0"
   for_each                = local.service_credential_names
-  region                  = local.secret_manager_region
-  secrets_manager_guid    = local.secret_manager_guid
+  region                  = local.secrets_manager_region
+  secrets_manager_guid    = local.secrets_manager_guid
   secret_group_id         = module.secrets_manager_secrets_group.secret_group_id
   secret_name             = "${var.prefix}-${each.key}-credentials"
   secret_description      = "MongoDB Service Credentials for ${each.key}"
@@ -172,8 +172,8 @@ module "secrets_manager_service_credentials_user_pass" {
 module "secrets_manager_service_credentials_cert" {
   source                    = "terraform-ibm-modules/secrets-manager-secret/ibm"
   version                   = "1.7.0"
-  region                    = local.secret_manager_region
-  secrets_manager_guid      = local.secret_manager_guid
+  region                    = local.secrets_manager_region
+  secrets_manager_guid      = local.secrets_manager_guid
   secret_group_id           = module.secrets_manager_secrets_group.secret_group_id
   secret_name               = "${var.prefix}-es-cert"
   secret_description        = "MongoDB Service Credential Certificate"

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -47,15 +47,15 @@ variable "plan" {
   default     = "enterprise"
 }
 
-variable "existing_secret_manager_instance_guid" {
+variable "existing_secrets_manager_instance_guid" {
   type        = string
   description = "Existing Secrets Manager GUID. If not provided an new instance will be provisioned"
   default     = null
 }
 
-variable "existing_secret_manager_instance_region" {
+variable "existing_secrets_manager_instance_region" {
   type        = string
-  description = "Required if value is passed into var.existing_secret_manager_instance_guid"
+  description = "Required if value is passed into var.existing_secrets_manager_instance_guid"
   default     = null
 }
 

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -226,16 +226,16 @@
               "key": "admin_pass"
             },
             {
-              "key": "admin_pass_secret_manager_secret_group"
+              "key": "admin_pass_secrets_manager_secret_group"
             },
             {
-              "key": "admin_pass_secret_manager_secret_name"
+              "key": "admin_pass_secrets_manager_secret_name"
             },
             {
               "key": "existing_mongodb_instance_crn"
             },
             {
-              "key": "use_existing_admin_pass_secret_manager_secret_group"
+              "key": "use_existing_admin_pass_secrets_manager_secret_group"
             },
             {
               "key": "users"
@@ -292,7 +292,7 @@
               "key": "service_credential_secrets"
             },
             {
-              "key": "skip_mongodb_secret_manager_auth_policy"
+              "key": "skip_mongodb_secrets_manager_auth_policy"
             }
           ]
         }

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -314,25 +314,25 @@ variable "service_credential_secrets" {
   }
 }
 
-variable "skip_mongodb_secret_manager_auth_policy" {
+variable "skip_mongodb_secrets_manager_auth_policy" {
   type        = bool
   description = "Whether an IAM authorization policy is created for Secrets Manager instance to create a service credential secrets for Databases for MongoDB. If set to false, the Secrets Manager instance passed by the user is granted the Key Manager access to the MongoDB instance created by the Deployable Architecture. Set to `true` to use an existing policy. The value of this is ignored if any value for 'existing_secrets_manager_instance_crn' is not passed."
   default     = false
 }
 
-variable "admin_pass_secret_manager_secret_group" {
+variable "admin_pass_secrets_manager_secret_group" {
   type        = string
   description = "The name of a new or existing secrets manager secret group for admin password. To use existing secret group, `use_existing_admin_pass_secrets_manager_secret_group` must be set to `true`. If a prefix input variable is specified, the prefix is added to the name in the `<prefix>-<name>` format."
   default     = "mongodb-secrets"
 }
 
-variable "use_existing_admin_pass_secret_manager_secret_group" {
+variable "use_existing_admin_pass_secrets_manager_secret_group" {
   type        = bool
   description = "Whether to use an existing secrets manager secret group for admin password."
   default     = false
 }
 
-variable "admin_pass_secret_manager_secret_name" {
+variable "admin_pass_secrets_manager_secret_name" {
   type        = string
   description = "The name of a new mongodb administrator secret. If a prefix input variable is specified, the prefix is added to the name in the `<prefix>-<name>` format."
   default     = "mongodb-admin-password"

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -192,6 +192,7 @@ variable "kms_endpoint_type" {
   type        = string
   description = "The type of endpoint to use for communicating with the Key Protect or Hyper Protect Crypto Services instance. Possible values: `public`, `private`. Applies only if `existing_kms_key_crn` is not specified."
   default     = "private"
+
   validation {
     condition     = can(regex("public|private", var.kms_endpoint_type))
     error_message = "The kms_endpoint_type value must be 'public' or 'private'."
@@ -304,6 +305,7 @@ variable "existing_secrets_manager_endpoint_type" {
   type        = string
   description = "The endpoint type to use if `existing_secrets_manager_instance_crn` is specified. Possible values: public, private."
   default     = "private"
+
   validation {
     condition     = contains(["public", "private"], var.existing_secrets_manager_endpoint_type)
     error_message = "Only \"public\" and \"private\" are allowed values for 'existing_secrets_endpoint_type'."
@@ -380,6 +382,7 @@ variable "admin_pass_secrets_manager_secret_name" {
   type        = string
   description = "The name of a new mongodb administrator secret. If a prefix input variable is specified, the prefix is added to the name in the `<prefix>-<name>` format."
   default     = "mongodb-admin-password"
+
   validation {
     condition = (
       var.existing_secrets_manager_instance_crn == null ||

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -364,9 +364,9 @@ variable "admin_pass_secrets_manager_secret_group" {
   validation {
     condition = (
       var.existing_secrets_manager_instance_crn == null ||
-      var.admin_pass_secret_manager_secret_group != null
+      var.admin_pass_secrets_manager_secret_group != null
     )
-    error_message = "`admin_pass_secret_manager_secret_group` is required when `existing_secrets_manager_instance_crn` is set."
+    error_message = "`admin_pass_secrets_manager_secret_group` is required when `existing_secrets_manager_instance_crn` is set."
   }
 }
 
@@ -383,8 +383,8 @@ variable "admin_pass_secrets_manager_secret_name" {
   validation {
     condition = (
       var.existing_secrets_manager_instance_crn == null ||
-      var.admin_pass_secret_manager_secret_name != null
+      var.admin_pass_secrets_manager_secret_name != null
     )
-    error_message = "`admin_pass_secret_manager_secret_name` is required when `existing_secrets_manager_instance_crn` is set."
+    error_message = "`admin_pass_secrets_manager_secret_name` is required when `existing_secrets_manager_instance_crn` is set."
   }
 }

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -2,11 +2,14 @@
 package test
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 )
 
@@ -54,4 +57,42 @@ func TestRunRestoredDBExample(t *testing.T) {
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
 	assert.NotNil(t, output, "Expected some output")
+}
+
+func TestRunCompleteExample(t *testing.T) {
+	t.Parallel()
+
+	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
+		Testing:            t,
+		TerraformDir:       "examples/complete",
+		Prefix:             "mongodb-upg",
+		BestRegionYAMLPath: regionSelectionPath,
+		ResourceGroup:      resourceGroup,
+		TerraformVars: map[string]interface{}{
+			"mongodb_version": "6.0", // Always lock to the lowest supported MongoDB version
+			"plan":            "standard",
+			"users": []map[string]interface{}{
+				{
+					"name":     "testuser",
+					"password": GetRandomAdminPassword(t),
+					"type":     "database",
+				},
+			},
+			"admin_pass": GetRandomAdminPassword(t),
+		},
+		CloudInfoService: sharedInfoSvc,
+	})
+
+	output, err := options.RunTestConsistency()
+	assert.Nil(t, err, "This should not have errored")
+	assert.NotNil(t, output, "Expected some output")
+}
+
+func GetRandomAdminPassword(t *testing.T) string {
+	// Generate a 15 char long random string for the admin_pass
+	randomBytes := make([]byte, 13)
+	_, randErr := rand.Read(randomBytes)
+	require.Nil(t, randErr) // do not proceed if we can't gen a random password
+	randomPass := "A1" + base64.URLEncoding.EncodeToString(randomBytes)[:13]
+	return randomPass
 }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -103,8 +103,8 @@ func TestRunStandardSolutionSchematics(t *testing.T) {
 		{Name: "service_credential_names", Value: "{\"admin_test\": \"Administrator\", \"editor_test\": \"Editor\"}", DataType: "map(string)"},
 		{Name: "existing_secrets_manager_instance_crn", Value: permanentResources["secretsManagerCRN"], DataType: "string"},
 		{Name: "service_credential_secrets", Value: serviceCredentialSecrets, DataType: "list(object)"},
-		{Name: "admin_pass_secret_manager_secret_group", Value: options.Prefix, DataType: "string"},
-		{Name: "admin_pass_secret_manager_secret_name", Value: options.Prefix, DataType: "string"},
+		{Name: "admin_pass_secrets_manager_secret_group", Value: options.Prefix, DataType: "string"},
+		{Name: "admin_pass_secrets_manager_secret_name", Value: options.Prefix, DataType: "string"},
 		{Name: "provider_visibility", Value: "private", DataType: "string"},
 		{Name: "prefix", Value: options.Prefix, DataType: "string"},
 	}


### PR DESCRIPTION
### Description

The following variables are named inconsistently/incorrectly:

- skip_mongodb_secret_manager_auth_policy
- admin_pass_secret_manager_secret_group
- use_existing_admin_pass_secret_manager_secret_group
- admin_pass_secret_manager_secret_name

They are correctly renamed for Secrets Manager

- skip_mongodb_secrets_manager_auth_policy
- admin_pass_secrets_manager_secret_group
- use_existing_admin_pass_secrets_manager_secret_group
- admin_pass_secrets_manager_secret_name

Is this a minor release, or a major release changing inputs in the DA?

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Inputs to the deployable architecture need updating. The following inputs are corrected, adding an `s` to make it secrets_manager.

- skip_mongodb_secret_manager_auth_policy becomes skip_mongodb_secrets_manager_auth_policy
- admin_pass_secret_manager_secret_group becomes admin_pass_secrets_manager_secret_group
- use_existing_admin_pass_secret_manager_secret_group becomes use_existing_admin_pass_secrets_manager_secret_group
- admin_pass_secret_manager_secret_name becomes admin_pass_secrets_manager_secret_name

If the DA is being consumed as code, terraform inputs will need updating before plan and apply can be run.
If the DA is being consumed via projects/schematics the old value with have to be put in the new property in the UI.

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
