### PR TITLE
fix: release_notes_url for community DA tile

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -26,7 +26,6 @@
       "short_description": "Creates and configures an instance of IBM Cloud Databases for MongoDB.",
       "long_description": "This architecture supports creating and configuring an instance of [Databases for MongoDB](https://www.ibm.com/products/databases-for-mongodb), with optional KMS encryption. \n\nLeverage [Terraform IBM Modules](https://github.com/terraform-ibm-modules) to shape and scale your solutions. You can integrate Terraform IBM Modules (TIM) to extend functionality and design a solution tailored to your environment and operations needs. These modules offer reusable, customizable elements that follow IBM Cloud's recommended practices. You can access the [source code and documentation](https://github.com/terraform-ibm-modules/terraform-ibm-icd-mongodb) and use it to extend your current architecture or create new solutions.\n\nℹ️ This Terraform-based automation is part of a broader suite of IBM-maintained Infrastructure as Code (IaC) assets, each following the naming pattern \"Cloud automation for *servicename*\" and focusing on single IBM Cloud service. These single-service deployable architectures can be used on their own to streamline and automate service deployments through an [IaC approach](https://cloud.ibm.com/docs/secure-enterprise?topic=secure-enterprise-understanding-projects), or assembled together into a broader [automated IaC stack](https://cloud.ibm.com/docs/secure-enterprise?topic=secure-enterprise-config-stack) to automate the deployment of an end-to-end solution architecture.",
       "offering_docs_url": "https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-about-tim",
-      "release_notes_url": "https://github.com/terraform-ibm-modules/terraform-ibm-icd-mongodb/releases",
       "offering_icon_url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-icd-mongodb/main/images/mongodb.svg",
       "provider_name": "IBM",
       "support_details": "This product is in the community registry, as such support is handled through the originated repo. If you experience issues please open an issue in the repository [https://github.com/terraform-ibm-modules/terraform-ibm-icd-mongodb/issues](https://github.com/terraform-ibm-modules/terraform-ibm-icd-mongodb/issues). Please note this product is not supported via the IBM Cloud Support Center.",
@@ -59,6 +58,7 @@
           "index": 1,
           "install_type": "fullstack",
           "working_directory": "solutions/fully-configurable",
+          "release_notes_url": "https://github.com/terraform-ibm-modules/terraform-ibm-icd-mongodb/releases",
           "short_description": "Ideal for users who want flexibility with a reliable starting point.",
           "iam_permissions": [
             {
@@ -484,6 +484,7 @@
           "index": 2,
           "install_type": "fullstack",
           "working_directory": "solutions/security-enforced",
+          "release_notes_url": "https://github.com/terraform-ibm-modules/terraform-ibm-icd-mongodb/releases",
           "short_description": "Ideal for users who want locked down enforced security.",
           "iam_permissions": [
             {


### PR DESCRIPTION

### Description

This PR fixes the `release_notes_url` in the `ibm_catalog.json` file for the community DA tile.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Fix `release_notes_url` in `ibm_catalog.json`.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
