### PR TITLE
fix: S2S policy and service credentials

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,9 +68,11 @@ locals {
 
 # Create IAM Authorization Policies to allow MongoDB to access KMS for the encryption key
 resource "ibm_iam_authorization_policy" "kms_policy" {
-  count                    = local.create_kms_auth_policy
-  source_service_name      = "databases-for-mongodb"
-  source_resource_group_id = var.resource_group_id
+  count               = local.create_kms_auth_policy
+  source_service_name = "databases-for-mongodb"
+  # See issue,https://github.com/terraform-ibm-modules/terraform-ibm-icd-postgresql/issues/885
+  # source_resource_group_id = var.resource_group_id
+  source_resource_group_id = local.is_classic ? var.resource_group_id : null
   roles                    = ["Reader", "Authorization Delegator"] # Authorization Delegator role required for backup encryption key
   description              = "Allow all MongoDB instances in the resource group ${var.resource_group_id} to read the ${local.kms_service} key ${local.kms_key_id} from the instance GUID ${local.kms_key_instance_guid}"
   resource_attributes {
@@ -393,8 +395,8 @@ locals {
     credentials = {
       for service_credential in ibm_resource_key.service_credentials :
       service_credential["name"] => {
-        username = can(service_credential.credentials["connection.mongodb.authentication.username"]) ? service_credential.credentials["connection.mongodb.authentication.username"] : null
-        password = can(service_credential.credentials["connection.mongodb.authentication.password"]) ? service_credential.credentials["connection.mongodb.authentication.password"] : null
+        username = local.is_gen2 ? service_credential.credentials["username"] : service_credential.credentials["connection.mongodb.authentication.username"]
+        password = local.is_gen2 ? service_credential.credentials["password"] : service_credential.credentials["connection.mongodb.authentication.password"]
       }
     }
   } : null

--- a/solutions/fully-configurable-gen2/main.tf
+++ b/solutions/fully-configurable-gen2/main.tf
@@ -95,13 +95,14 @@ locals {
 
 # Create auth policy (scoped to exact KMS key)
 resource "ibm_iam_authorization_policy" "kms_policy" {
-  count                    = local.create_cross_account_kms_auth_policy ? 1 : 0
-  provider                 = ibm.kms
-  source_service_account   = local.account_id
-  source_service_name      = "databases-for-mongodb"
-  source_resource_group_id = module.resource_group.resource_group_id
-  roles                    = ["Reader", "Authorization Delegator"]
-  description              = "Allow all MongoDB instances in the resource group ${module.resource_group.resource_group_id} in the account ${local.account_id} to read the ${local.kms_service} key ${local.kms_key_id} from the instance GUID ${local.kms_instance_guid}"
+  count                  = local.create_cross_account_kms_auth_policy ? 1 : 0
+  provider               = ibm.kms
+  source_service_account = local.account_id
+  source_service_name    = "databases-for-mongodb"
+  # See issue,https://github.com/terraform-ibm-modules/terraform-ibm-icd-postgresql/issues/885
+  # source_resource_group_id = module.resource_group.resource_group_id
+  roles       = ["Reader", "Authorization Delegator"]
+  description = "Allow all MongoDB instances in the resource group ${module.resource_group.resource_group_id} in the account ${local.account_id} to read the ${local.kms_service} key ${local.kms_key_id} from the instance GUID ${local.kms_instance_guid}"
   resource_attributes {
     name     = "serviceName"
     operator = "stringEquals"

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
-	github.com/go-git/go-git/v5 v5.19.1 // indirect
+	github.com/go-git/go-git/v5 v5.19.2 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -74,8 +74,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
-github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.2 h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
+github.com/go-git/go-git/v5 v5.19.2/go.mod h1:QqCBE1EFN5ddFmrliLQ3/ntRCUjZU3EJuwuB/jWEHjk=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
### Description

https://github.com/terraform-ibm-modules/terraform-ibm-icd-mongodb/issues/793

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Changes includes the conditional logic around the resource group scoping of S2S authorization policy for Gen2 instances and corrects the service credential path.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
